### PR TITLE
allow file editing even though that file is already uploaded

### DIFF
--- a/link_to_repo_dist.sh
+++ b/link_to_repo_dist.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Usage: ./link_to_repo.sh <your_root_repository_directory>
+# Afterwards, run `npm run build` to see the changes in the repository 
+
+# Check if the absolute path to the repository root directory provided
+
+repository_root_path=$1
+
+if [ -z "$repository_root_path" ]; then
+    echo "Please provide the path to the repository root directory. Example: ./link_to_repo.sh /home/<user>/repozitare/nr-docs"
+    exit 1
+fi
+
+repository_file_manager_dist_path="$repository_root_path/.venv/var/instance/assets/node_modules/@oarepo/file-manager/dist"
+expected_files=("file-manager.es.js" "file-manager.umd.js")
+
+# Check if the repository dist directory exists and remove it if it does
+# For safety reasons, check if the path contains the correct file names
+
+if [ -d "$repository_file_manager_dist_path" ]; then
+    for file in "${expected_files[@]}"; do
+        if ! [ -f "$repository_file_manager_dist_path/$file" ]; then
+            echo "The repository dist directory does not contain the expected files. Please check the path."
+            exit 1
+        fi
+    done
+
+    rm -rf "$repository_file_manager_dist_path"
+fi
+
+# Create a symbolic link to the repository dist directory
+
+ln -s "$(pwd)/dist" "$repository_file_manager_dist_path"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oarepo/file-manager",
   "private": false,
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "File management component for Open Access Repository.",
   "type": "module",
   "scripts": {

--- a/src/components/file-management-dialog/UppyDashboardDialog.jsx
+++ b/src/components/file-management-dialog/UppyDashboardDialog.jsx
@@ -174,6 +174,7 @@ const UppyDashboardDialog = ({
               return true;
             }
           : (file, files) => {
+              if (startEvent?.event == "edit-file") return true;
               const hasDuplicateInCurrentSession = Object.hasOwn(
                 files,
                 file.id

--- a/src/components/file-management-dialog/UppyDashboardDialog.jsx
+++ b/src/components/file-management-dialog/UppyDashboardDialog.jsx
@@ -121,8 +121,6 @@ const UppyDashboardDialog = ({
             },
           },
       locale: customLocale,
-      // allowMultipleUploadBatches:
-      //   startEvent?.event === "edit-file" ? false : true,
       restrictions: {
         allowedFileTypes: allowedFileTypes,
         maxNumberOfFiles: startEvent?.event === "edit-file" ? 1 : null,

--- a/src/components/file-management-dialog/UppyDashboardDialog.jsx
+++ b/src/components/file-management-dialog/UppyDashboardDialog.jsx
@@ -121,8 +121,8 @@ const UppyDashboardDialog = ({
             },
           },
       locale: customLocale,
-      allowMultipleUploadBatches:
-        startEvent?.event === "edit-file" ? false : true,
+      // allowMultipleUploadBatches:
+      //   startEvent?.event === "edit-file" ? false : true,
       restrictions: {
         allowedFileTypes: allowedFileTypes,
         maxNumberOfFiles: startEvent?.event === "edit-file" ? 1 : null,


### PR DESCRIPTION
In previous PR, I made changes to prevent placing same file in the uploader, but this broke editing of the file (as the file already exists it just reject, when you try to open uppy dialog).

I get a weird error 
![image](https://github.com/user-attachments/assets/fd8a0be8-920c-41bd-a39a-6ca1a88ec550)


After modifying metadata and saving, even though everything seems to be ok (meaning the file gets saved normally). 

When I remove these two lines, all seems ok, though I am not sure if it is breaking anything else....
![image](https://github.com/user-attachments/assets/8e37f0fd-57c9-4bec-ab59-c880c60ae98e)

Please check it out, I am not sure if it breaks something else.


