### PR TITLE
feat(worker): make pdf extraction worker toggleable

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -17,10 +17,11 @@ const config = {
   core: {
     disableTelemetry: true
   },
-  previewHead: (head) => `
-    ${head}
-    <meta   http-equiv=\"Content-Security-Policy\" content=\"default-src 'self'; style-src 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; img-src 'self' blob:; media-src 'self'; connect-src 'self'\" />
-  `,
+  // Uncomment this to test in production-like CSP environment
+  // previewHead: (head) => `
+  //   ${head}
+  //   <meta   http-equiv=\"Content-Security-Policy\" content=\"default-src 'self'; style-src 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; img-src 'self' blob:; media-src 'self'; connect-src 'self'\" />
+  // `,
   async viteFinal (config, options) {
     return config;
   },

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -17,6 +17,10 @@ const config = {
   core: {
     disableTelemetry: true
   },
+  previewHead: (head) => `
+    ${head}
+    <meta   http-equiv=\"Content-Security-Policy\" content=\"default-src 'self'; style-src 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; img-src 'self' blob:; media-src 'self'; connect-src 'self'\" />
+  `,
   async viteFinal (config, options) {
     return config;
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oarepo/file-manager",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oarepo/file-manager",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "dependencies": {
         "@uppy/core": "^3.12.0",
         "@uppy/dashboard": "^3.8.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oarepo/file-manager",
   "private": false,
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "File management component for Open Access Repository.",
   "type": "module",
   "scripts": {

--- a/src/components/file-management-dialog/FileManagementDialog.jsx
+++ b/src/components/file-management-dialog/FileManagementDialog.jsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { useState, Suspense, lazy } from "react";
 import { createPortal } from "react-dom";
 import { WorkerProvider } from "../../contexts/WorkerProvider";
@@ -38,44 +39,39 @@ const FileManagementDialog = ({
 
   // TODO: this is a hacky approach to make pdf extraction worker toggleable
   // a bigger refactor is needed
-  const uppyModal = (
-    <Suspense
-      fallback={suspenseFallbackComponent}
-    >
-      {modalOpen && (
-        <UppyProvider>
-          {createPortal(
-            <UppyDashboardDialog
-              modalOpen={modalOpen}
-              setModalOpen={setModalOpen}
-              modifyExistingFiles={modifyExistingFiles}
-              allowedFileTypes={allowedFileTypes}
-              allowedMetaFields={allowedMetaFields}
-              autoExtractImagesFromPDFs={autoExtractImagesFromPDFs}
-              extraUppyCoreSettings={extraUppyCoreSettings}
-              startEvent={startEvent}
-              locale={locale}
-              extraUppyDashboardProps={extraUppyDashboardProps}
-              debug={debug}
-              onCompletedUpload={onCompletedUpload}
-            />,
-            document.body
-          )}
-        </UppyProvider>
-      )}
-    </Suspense>
-  );
+  const UppyWrapper = autoExtractImagesFromPDFs ? WorkerProvider : React.Fragment;
 
   return (
     <>
       <TriggerComponent onClick={() => setModalOpen(!modalOpen)} />
       <AppContextProvider value={config}>
-        {autoExtractImagesFromPDFs && (
-          <WorkerProvider>
-            {uppyModal}
-          </WorkerProvider>
-        ) || <>{uppyModal}</>
-        }
+        <UppyWrapper>
+          <Suspense
+            fallback={suspenseFallbackComponent}
+          >
+            {modalOpen && (
+              <UppyProvider>
+                {createPortal(
+                  <UppyDashboardDialog
+                    modalOpen={modalOpen}
+                    setModalOpen={setModalOpen}
+                    modifyExistingFiles={modifyExistingFiles}
+                    allowedFileTypes={allowedFileTypes}
+                    allowedMetaFields={allowedMetaFields}
+                    autoExtractImagesFromPDFs={autoExtractImagesFromPDFs}
+                    extraUppyCoreSettings={extraUppyCoreSettings}
+                    startEvent={startEvent}
+                    locale={locale}
+                    extraUppyDashboardProps={extraUppyDashboardProps}
+                    debug={debug}
+                    onCompletedUpload={onCompletedUpload}
+                  />,
+                  document.body
+                )}
+              </UppyProvider>
+            )}
+          </Suspense>
+        </UppyWrapper>
       </AppContextProvider>
     </>
   );

--- a/src/components/file-management-dialog/UppyDashboardDialog.jsx
+++ b/src/components/file-management-dialog/UppyDashboardDialog.jsx
@@ -63,7 +63,7 @@ const UppyDashboardDialog = ({
   // }
   const handleUploadClick = useCallback(
     async (file) => {
-      if (!autoExtractImagesFromPDFs) { return; }
+      if (!autoExtractImagesFromPDFs || !extractImageWorker) { return; }
       if (window.Worker) {
         if (isProcessing.current) {
           uppy.info(uppy.i18n("Still processing previous file."), "info", 3000);
@@ -390,7 +390,7 @@ const UppyDashboardDialog = ({
 
   useEffect(() => {
     // after PDFImageExtractor Extract Images button is clicked, register onmessage callback
-    if (!autoExtractImagesFromPDFs) { return; }
+    if (!autoExtractImagesFromPDFs || !extractImageWorker) { return; }
   
     if (window.Worker) {
       extractImageWorker.onmessage = (event) => {

--- a/src/components/file-management-dialog/UppyDashboardDialog.jsx
+++ b/src/components/file-management-dialog/UppyDashboardDialog.jsx
@@ -63,6 +63,7 @@ const UppyDashboardDialog = ({
   // }
   const handleUploadClick = useCallback(
     async (file) => {
+      if (!autoExtractImagesFromPDFs) { return; }
       if (window.Worker) {
         if (isProcessing.current) {
           uppy.info(uppy.i18n("Still processing previous file."), "info", 3000);
@@ -94,7 +95,7 @@ const UppyDashboardDialog = ({
         uppy.info(uppy.i18n("Web Worker is not supported"), "info", 5000);
       }
     },
-    [uppy, extractImageWorker, isProcessing]
+    [uppy, extractImageWorker, autoExtractImagesFromPDFs, isProcessing]
   );
 
   useEffect(() => {
@@ -389,6 +390,8 @@ const UppyDashboardDialog = ({
 
   useEffect(() => {
     // after PDFImageExtractor Extract Images button is clicked, register onmessage callback
+    if (!autoExtractImagesFromPDFs) { return; }
+  
     if (window.Worker) {
       extractImageWorker.onmessage = (event) => {
         if (event.data?.type === "done") {
@@ -438,7 +441,7 @@ const UppyDashboardDialog = ({
     } else {
       uppy.info(uppy.i18n("Web Worker is not supported"), "error", 5000);
     }
-  }, [extractImageWorker, uppy, debug]);
+  }, [extractImageWorker, autoExtractImagesFromPDFs, uppy, debug]);
 
   const manualI18n = (key) => {
     const localeStrings = locale?.startsWith("cs")

--- a/src/components/file-management-dialog/UppyDashboardDialog.stories.jsx
+++ b/src/components/file-management-dialog/UppyDashboardDialog.stories.jsx
@@ -1,5 +1,5 @@
 import UppyDashboardDialog from "./UppyDashboardDialog";
-import { WorkerProvider } from "../../contexts/WorkerContext";
+import { WorkerProvider } from "../../contexts/WorkerProvider";
 import { UppyProvider } from "../../contexts/UppyContext";
 import { AppContextProvider } from "../../contexts/AppContext";
 

--- a/src/contexts/WorkerContext.jsx
+++ b/src/contexts/WorkerContext.jsx
@@ -1,11 +1,3 @@
-import { useMemo, createContext } from "react";
-import ExtractImagesWorker from "../workers/extract-images-worker?worker&inline";
+import { createContext } from "react";
 
 export const WorkerContext = createContext(null);
-
-export const WorkerProvider = ({ children }) => {
-  const worker = useMemo(() => ExtractImagesWorker(), []);
-  return (
-    <WorkerContext.Provider value={worker}>{children}</WorkerContext.Provider>
-  );
-};

--- a/src/contexts/WorkerProvider.jsx
+++ b/src/contexts/WorkerProvider.jsx
@@ -6,8 +6,8 @@ export const WorkerProvider = ({ children }) => {
 
   React.useEffect(() => {
     const installWorker = async () => {
-        const worker = await import("../workers/extract-images-worker?worker&inline").default;
-        setWorker(worker);
+        const worker = await import("../workers/extract-images-worker?worker&inline");
+        setWorker(worker.default);
     }
 
     installWorker();

--- a/src/contexts/WorkerProvider.jsx
+++ b/src/contexts/WorkerProvider.jsx
@@ -1,0 +1,10 @@
+import { useMemo } from "react";
+import ExtractImagesWorker from "../workers/extract-images-worker?worker&inline";
+import { WorkerContext } from "./WorkerContext";
+
+export const WorkerProvider = ({ children }) => {
+  const worker = useMemo(() => ExtractImagesWorker(), []);
+  return (
+    <WorkerContext.Provider value={worker}>{children}</WorkerContext.Provider>
+  );
+};

--- a/src/contexts/WorkerProvider.jsx
+++ b/src/contexts/WorkerProvider.jsx
@@ -1,9 +1,18 @@
-import { useMemo } from "react";
-import ExtractImagesWorker from "../workers/extract-images-worker?worker&inline";
+import * as React from 'react';
 import { WorkerContext } from "./WorkerContext";
 
 export const WorkerProvider = ({ children }) => {
-  const worker = useMemo(() => ExtractImagesWorker(), []);
+  const [worker, setWorker] = React.useState();
+
+  React.useEffect(() => {
+    const installWorker = async () => {
+        const worker = await import("../workers/extract-images-worker?worker&inline").default;
+        setWorker(worker);
+    }
+
+    installWorker();
+  }, [])
+
   return (
     <WorkerContext.Provider value={worker}>{children}</WorkerContext.Provider>
   );

--- a/src/contexts/index.js
+++ b/src/contexts/index.js
@@ -1,3 +1,4 @@
 export * from './AppContext'
 export * from './UppyContext'
 export * from './WorkerContext'
+export * from './WorkerProvider'

--- a/src/hooks/useWorker.js
+++ b/src/hooks/useWorker.js
@@ -3,9 +3,12 @@ import { WorkerContext } from "../contexts/WorkerContext";
 
 const useWorker = () => {
   const worker = useContext(WorkerContext);
-  if (worker === null) {
-    throw new Error("useWorker must be used within a WorkerProvider");
-  }
+  // TODO: Extraction worker context shouldn't be there when
+  // autoExtract feature is disabled
+  //
+  // if (worker === null) {
+  //   throw new Error("useWorker must be used within a WorkerProvider");
+  // }
   return worker;
 };
 


### PR DESCRIPTION
It is undesirable to load web worker inline script for PDF image extraction, when extraction feature is disabled. When enabled, CSP rule issues needs to be fixed (we don't want to allow `data:` or `blob:` for scripts as it would open up for XSS, and the following currently happens with inline web worker:

![Screenshot 2025-05-15 at 13 41 33](https://github.com/user-attachments/assets/bf425aec-5207-4724-8118-f1dde76f467d)

Theoretically, we can reduce the risks by allowing it exclusively for web-workers, not for all scripts globally:
```
"worker-src": ["'self'", "blob:", "data:"],
```
But the best way would be to load it on the page as pre-packaged bundle, when PDF image extraction is enabled & needed